### PR TITLE
replace gcc.nativeTools with cc.nativeTools in clang

### DIFF
--- a/pkgs/development/compilers/llvm/3.4/clang.nix
+++ b/pkgs/development/compilers/llvm/3.4/clang.nix
@@ -2,7 +2,7 @@
 
 # be sure not to rebuild clang on darwin; some packages request it specifically
 # we need to fix those
-assert stdenv.isDarwin -> stdenv.gcc.nativeTools;
+assert stdenv.isDarwin -> stdenv.cc.nativeTools;
 
 stdenv.mkDerivation {
   name = "clang-${version}";


### PR DESCRIPTION
Before:

```
russruss@Lustgarten ~/p/nixpkgs> nix-env -q -f ~/proj/nixpkgs/  --show-trace
error: while evaluating `clangWrapSelf' at /Users/russruss/proj/nixpkgs/pkgs/top-level/all-packages.nix:2926:19, called from /Users/russruss/proj/nixpkgs/pkgs/top-level/all-packages.nix:2924:15:
while evaluating anonymous function at /Users/russruss/proj/nixpkgs/pkgs/build-support/gcc-wrapper/default.nix:8:1, called from /Users/russruss/proj/nixpkgs/pkgs/top-level/all-packages.nix:2926:26:
while evaluating the attribute `clang' at /Users/russruss/proj/nixpkgs/pkgs/development/compilers/llvm/3.4/default.nix:23:5:
while evaluating `callPackageWith' at /Users/russruss/proj/nixpkgs/lib/customisation.nix:97:35, called from /Users/russruss/proj/nixpkgs/pkgs/development/compilers/llvm/3.4/default.nix:23:13:
while evaluating `makeOverridable' at /Users/russruss/proj/nixpkgs/lib/customisation.nix:56:24, called from /Users/russruss/proj/nixpkgs/lib/customisation.nix:99:5:
while evaluating anonymous function at /Users/russruss/proj/nixpkgs/pkgs/development/compilers/llvm/3.4/clang.nix:1:1, called from /Users/russruss/proj/nixpkgs/lib/customisation.nix:58:12:
attribute `gcc.nativeTools' missing, at /Users/russruss/proj/nixpkgs/pkgs/development/compilers/llvm/3.4/clang.nix:5:27
```

After, works successfully