### PR TITLE
A working version of Python 2.7.

### DIFF
--- a/pkgs/development/interpreters/python/2.7/default.nix
+++ b/pkgs/development/interpreters/python/2.7/default.nix
@@ -70,7 +70,7 @@ let
     C_INCLUDE_PATH = concatStringsSep ":" (map (p: "${p}/include") buildInputs);
     LIBRARY_PATH = concatStringsSep ":" (map (p: "${p}/lib") buildInputs);
 
-    configureFlags = "--enable-shared --with-threads --enable-unicode" + stdenv.lib.optionalString stdenv.isDarwin " --disable-toolbox-glue";
+    configureFlags = "--enable-shared --with-threads --enable-unicode --without-gcc" + stdenv.lib.optionalString stdenv.isDarwin " --disable-toolbox-glue";
 
     NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin "-msse2";
 


### PR DESCRIPTION
Confession: I'm stumbling around Nix like a drunken monkey, so this may not be The Right Way To Do It. Nevertheless, this patch gets python 2.7 working from the pure-darwin branch. And with it, a lot of packages that depend on python. So I figure it's worth sending the details back upstream... :-)
