### PR TITLE
Make urxvt work on OS X.

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation (rec {
   patches = [
     ./rxvt-unicode-9.06-font-width.patch
     ./rxvt-unicode-256-color-resources.patch
-  ];
+  ]
+  ++ stdenv.lib.optional stdenv.isDarwin ./rxvt-unicode-makefile-phony.patch;
 
   preConfigure =
     ''

--- a/pkgs/applications/misc/rxvt_unicode/rxvt-unicode-makefile-phony.patch
+++ b/pkgs/applications/misc/rxvt_unicode/rxvt-unicode-makefile-phony.patch
@@ -1,0 +1,10 @@
+--- a/Makefile.in	2015-01-13 08:52:30.000000000 +0100
++++ b/Makefile.in	2015-01-13 08:52:58.000000000 +0100
+@@ -30,6 +30,7 @@
+ subdirs = src doc
+ 
+ RECURSIVE_TARGETS = all allbin alldoc tags clean distclean realclean install
++.PHONY: $(RECURSIVE_TARGETS)
+ 
+ #-------------------------------------------------------------------------
+ 


### PR DESCRIPTION
Due to the case-insensitive file system on OS X, `make install` does
nothing, since it sees the INSTALL file as the up-to-date target.
Adding a .PHONY target to the Makefile fixes this.